### PR TITLE
vboxmanage property changed

### DIFF
--- a/demo/Vagrantfile
+++ b/demo/Vagrantfile
@@ -16,8 +16,15 @@ Vagrant.configure('2') do |config|
     v.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
     # No audo
     v.customize ["modifyvm", :id, "--audio", "none"]
+	process = `"#{ENV["VBOX_MSI_INSTALL_PATH"]}vboxmanage.exe" -v`
+	
     # Clipboard enabled
-    v.customize ["modifyvm", :id, "--clipboard", "bidirectional"]
+    if process[0,5] >= '6.1.0' then
+		# Clipboard enabled
+		v.customize ["modifyvm", :id, "--clipboard-mode", "bidirectional"]
+	else
+		v.customize ["modifyvm", :id, "--clipboard", "bidirectional"]
+	end
     v.customize ["modifyvm", :id, "--draganddrop", "hosttoguest"]
     # For performance
     v.customize ["modifyvm", :id, "--usb", "off"]


### PR DESCRIPTION
In the latest release of virtualbox, the "--clipboard" setting has been renamed to "--clipboard-mode".  So, to ensure that the vagrantfile still works regardless of the version of virtualbox being used, I added some ruby within the virtualbox provider block to obtain the version of vboxmanage and use the appropriate property value based on the returned version